### PR TITLE
fix: change config to publish package as public

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "https://github.com/snyk/composer-lockfile-parser.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "snyk",
     "php",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add `publishConfig` key to `package.json` so this package will be published as public, not private