### PR TITLE
There is a comma placed in front of name in line2. Removed the comma …

### DIFF
--- a/test/fixtures/composer-invalid-json/composer.json
+++ b/test/fixtures/composer-invalid-json/composer.json
@@ -1,5 +1,5 @@
 {
-	,"name" : "adodb/adodb-php",
+	"name" : "adodb/adodb-php",
 	"description" : "ADOdb is a PHP database abstraction layer library",
 	"license" : [ "LGPL-2.1", " BSD-2-Clause" ],
 	"authors" : [


### PR DESCRIPTION
…character.

Wrong syntax:
,"name" : "adodb/adodb-php",

Correct Syntax:
"name" : "adodb/adodb-php",

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
