### PR TITLE
test: eliminate sync-request, which is node >=8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "devDependencies": {
     "@types/lodash": "4.14.133",
     "@types/node": "6.14.6",
-    "sync-request": "6.1.0",
+    "@types/node-fetch": "^2.5.2",
+    "node-fetch": "^2.6.0",
     "tap": "12.7.0",
     "tslint": "5.17.0",
     "typescript": "3.5.1"

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as tap from 'tap';
 import * as _ from 'lodash';
 import * as path from 'path';
-import request from 'sync-request';
+import fetch from 'node-fetch';
 
 import { buildDepTreeFromFiles } from '../lib';
 import { systemVersionsStub } from './stubs/system_deps_stub';
@@ -212,12 +212,12 @@ tap.test('with alias in external repo', async (t) => {
 
     // sometimes we hit the github api limit, so we use a mock
     try {
-      const res = request('GET', apiBranchesUrl, {
+      const res = await fetch(apiBranchesUrl, {
         headers: {
           'user-agent': 'CI Testing',
         },
       });
-      branchesData = JSON.parse(res.getBody().toString());
+      branchesData = await res.json();
     } catch (error) {
       branchesData = [
         {name: 'my-bugfix'},


### PR DESCRIPTION
#### What does this PR do?

Eliminate `sync-request`, which is documented to not work on node below 8 (for us it hangs, or crashes), by replacing it with `node-fetch`. This fixes the tests on `node 6`.