### PR TITLE
fix: invalid json in test fixture

### DIFF
--- a/test/fixtures/composer-invalid-json/composer.json
+++ b/test/fixtures/composer-invalid-json/composer.json
@@ -1,5 +1,5 @@
 {
-	,"name" : "adodb/adodb-php",
+	"name" : "adodb/adodb-php",
 	"description" : "ADOdb is a PHP database abstraction layer library",
 	"license" : [ "LGPL-2.1", " BSD-2-Clause" ],
 	"authors" : [


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Remove a `,` from a test fixture that makes the json invalid.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

Stumbled on this because it causes `flow` type check to fail

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
