### PR TITLE
feat: add ability to parse dev packages

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as _ from 'lodash';
 import * as path from 'path';
 
 import { InvalidUserInputError } from './errors';
@@ -11,7 +12,8 @@ function buildDepTree(
   manifestFileContent: string,
   defaultProjectName: string,
   systemVersions: SystemPackages,
-  includeDev = false): ComposerParserResponse {
+  includeDev = false,
+): ComposerParserResponse {
 
   const lockFileJson: ComposerLockFile = FileParser.parseLockFile(lockFileContent);
   const manifestJson: ComposerJsonFile = FileParser.parseManifestFile(manifestFileContent);
@@ -24,19 +26,19 @@ function buildDepTree(
   const version: string = ComposerParser.getVersion(manifestJson) || '0.0.0';
   const dependencies = ComposerParser.buildDependencies(
     manifestJson,
-    lockFileJson.packages,
+    lockFileJson,
     manifestJson,
-    [`${name}@${version}`],
     systemVersions,
     includeDev,
   );
+  const hasDevDependencies = !_.isEmpty(manifestJson['require-dev']);
 
   return {
     name,
     version,
     dependencies,
+    hasDevDependencies,
     packageFormatVersion: 'composer:0.0.1',
-    hasDevDependencies: includeDev,
   };
 }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -21,7 +21,7 @@ export interface ComposerDependencies {
 
 export interface ComposerLockFile {
   packages: LockFilePackage[];
-  'packages-dev'?: LockFileDependencies[];
+  'packages-dev'?: LockFilePackage[];
 }
 
 /**

--- a/test/fixtures/circular_deps_php_project/composer_deps.json
+++ b/test/fixtures/circular_deps_php_project/composer_deps.json
@@ -19,12 +19,24 @@
                 "php": {
                   "name": "php",
                   "version": "7.1",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": {
+                    "scope": "prod"
+                  }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         }
+      },
+      "labels": {
+        "scope": "prod"
       }
     },
     "symfony/polyfill-mbstring": {
@@ -46,14 +58,29 @@
                     "php": {
                       "name": "php",
                       "version": "7.1",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": {
+                        "scope": "prod"
+                      }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         }
+      },
+      "labels": {
+        "scope": "prod"
       }
     },
     "symfony/debug": {
@@ -75,12 +102,24 @@
                     "php": {
                       "name": "php",
                       "version": "7.1",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": {
+                        "scope": "prod"
+                      }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "psr/log": {
@@ -102,22 +141,43 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         }
+      },
+      "labels": {
+        "scope": "prod"
       }
     },
     "ext-dom": {
       "name": "ext-dom",
       "version": "20031129",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": {
+        "scope": "prod"
+      }
     },
     "phpunit/phpunit": {
       "name": "phpunit/phpunit",
@@ -126,27 +186,42 @@
         "ext-dom": {
           "name": "ext-dom",
           "version": "20031129",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": {
+            "scope": "prod"
+          }
         },
         "ext-json": {
           "name": "ext-json",
           "version": "1.5.0",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": {
+            "scope": "prod"
+          }
         },
         "ext-libxml": {
           "name": "ext-libxml",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": {
+            "scope": "prod"
+          }
         },
         "ext-mbstring": {
           "name": "ext-mbstring",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": {
+            "scope": "prod"
+          }
         },
         "ext-xml": {
           "name": "ext-xml",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": {
+            "scope": "prod"
+          }
         },
         "myclabs/deep-copy": {
           "name": "myclabs/deep-copy",
@@ -167,14 +242,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phar-io/manifest": {
@@ -184,12 +274,18 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": {
+                "scope": "prod"
+              }
             },
             "ext-phar": {
               "name": "ext-phar",
               "version": "*",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": {
+                "scope": "prod"
+              }
             },
             "phar-io/version": {
               "name": "phar-io/version",
@@ -210,14 +306,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "php": {
@@ -235,14 +346,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phar-io/version": {
@@ -264,14 +390,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "php": {
@@ -289,12 +430,24 @@
                     "php": {
                       "name": "php",
                       "version": "7.1",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": {
+                        "scope": "prod"
+                      }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phpspec/prophecy": {
@@ -316,12 +469,24 @@
                         "doctrine/instantiator": {
                           "name": "doctrine/instantiator",
                           "version": "1.2.x-dev",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "php": {
@@ -339,12 +504,24 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "phpdocumentor/reflection-docblock": {
@@ -366,12 +543,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "phpdocumentor/reflection-common": {
@@ -393,14 +582,29 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "phpdocumentor/type-resolver": {
@@ -422,12 +626,24 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     },
                     "phpdocumentor/reflection-common": {
@@ -449,16 +665,34 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": {
+                                        "scope": "prod"
+                                      }
                                     }
+                                  },
+                                  "labels": {
+                                    "scope": "prod"
                                   }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "webmozart/assert": {
@@ -480,16 +714,34 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/comparator": {
@@ -511,12 +763,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "sebastian/diff": {
@@ -538,14 +802,29 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "sebastian/exporter": {
@@ -567,12 +846,24 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     },
                     "sebastian/recursion-context": {
@@ -594,18 +885,39 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": {
+                                        "scope": "prod"
+                                      }
                                     }
+                                  },
+                                  "labels": {
+                                    "scope": "prod"
                                   }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/recursion-context": {
@@ -627,16 +939,34 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phpunit/php-code-coverage": {
@@ -646,12 +976,18 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": {
+                "scope": "prod"
+              }
             },
             "ext-xmlwriter": {
               "name": "ext-xmlwriter",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": {
+                "scope": "prod"
+              }
             },
             "php": {
               "name": "php",
@@ -668,12 +1004,24 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "phpunit/php-file-iterator": {
@@ -695,14 +1043,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "phpunit/php-text-template": {
@@ -724,14 +1087,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "phpunit/php-token-stream": {
@@ -741,7 +1119,10 @@
                 "ext-tokenizer": {
                   "name": "ext-tokenizer",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": {
+                    "scope": "prod"
+                  }
                 },
                 "php": {
                   "name": "php",
@@ -758,14 +1139,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/code-unit-reverse-lookup": {
@@ -787,14 +1183,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/environment": {
@@ -816,14 +1227,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/version": {
@@ -845,14 +1271,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "theseer/tokenizer": {
@@ -862,17 +1303,26 @@
                 "ext-dom": {
                   "name": "ext-dom",
                   "version": "20031129",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": {
+                    "scope": "prod"
+                  }
                 },
                 "ext-tokenizer": {
                   "name": "ext-tokenizer",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": {
+                    "scope": "prod"
+                  }
                 },
                 "ext-xmlwriter": {
                   "name": "ext-xmlwriter",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": {
+                    "scope": "prod"
+                  }
                 },
                 "php": {
                   "name": "php",
@@ -889,16 +1339,34 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phpunit/php-file-iterator": {
@@ -920,14 +1388,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phpunit/php-text-template": {
@@ -949,14 +1432,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phpunit/php-timer": {
@@ -978,14 +1476,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "phpunit/phpunit-mock-objects": {
@@ -1007,12 +1520,24 @@
                         "doctrine/instantiator": {
                           "name": "doctrine/instantiator",
                           "version": "1.2.x-dev",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "php": {
@@ -1030,12 +1555,24 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "phpunit/php-text-template": {
@@ -1057,14 +1594,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/exporter": {
@@ -1086,12 +1638,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "sebastian/recursion-context": {
@@ -1113,18 +1677,39 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/comparator": {
@@ -1146,12 +1731,24 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/diff": {
@@ -1173,14 +1770,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/exporter": {
@@ -1202,12 +1814,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "sebastian/recursion-context": {
@@ -1229,18 +1853,39 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/diff": {
@@ -1262,14 +1907,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/environment": {
@@ -1291,14 +1951,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/exporter": {
@@ -1320,12 +1995,24 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/recursion-context": {
@@ -1347,16 +2034,34 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/global-state": {
@@ -1378,14 +2083,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/object-enumerator": {
@@ -1407,12 +2127,24 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/object-reflector": {
@@ -1434,14 +2166,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "sebastian/recursion-context": {
@@ -1463,16 +2210,34 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/resource-operations": {
@@ -1494,14 +2259,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "sebastian/version": {
@@ -1523,16 +2303,34 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         }
+      },
+      "labels": {
+        "scope": "prod"
       }
     },
     "okaufmann/swiss-weather-api": {
@@ -1562,14 +2360,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "guzzlehttp/psr7": {
@@ -1591,12 +2404,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "psr/http-message": {
@@ -1618,16 +2443,34 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "php": {
@@ -1645,14 +2488,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "illuminate/support": {
@@ -1674,18 +2532,33 @@
                         "doctrine/inflector": {
                           "name": "doctrine/inflector",
                           "version": "1.3.x-dev",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "ext-mbstring": {
               "name": "ext-mbstring",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": {
+                "scope": "prod"
+              }
             },
             "illuminate/contracts": {
               "name": "illuminate/contracts",
@@ -1706,12 +2579,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "psr/container": {
@@ -1733,14 +2618,29 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "psr/simple-cache": {
@@ -1762,16 +2662,34 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "nesbot/carbon": {
@@ -1793,12 +2711,24 @@
                             "php": {
                               "name": "php",
                               "version": "7.1",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": {
+                                "scope": "prod"
+                              }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 },
                 "symfony/translation": {
@@ -1820,12 +2750,24 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": {
+                                    "scope": "prod"
+                                  }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     },
                     "symfony/polyfill-mbstring": {
@@ -1847,18 +2789,39 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": {
+                                        "scope": "prod"
+                                      }
                                     }
+                                  },
+                                  "labels": {
+                                    "scope": "prod"
                                   }
                                 }
+                              },
+                              "labels": {
+                                "scope": "prod"
                               }
                             }
+                          },
+                          "labels": {
+                            "scope": "prod"
                           }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             },
             "php": {
@@ -1876,14 +2839,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "kevinrob/guzzle-cache-middleware": {
@@ -1905,14 +2883,29 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "php": {
@@ -1930,12 +2923,24 @@
                     "php": {
                       "name": "php",
                       "version": "7.1",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": {
+                        "scope": "prod"
+                      }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         },
         "spatie/regex": {
@@ -1957,16 +2962,34 @@
                         "php": {
                           "name": "php",
                           "version": "7.1",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": {
+                            "scope": "prod"
+                          }
                         }
+                      },
+                      "labels": {
+                        "scope": "prod"
                       }
                     }
+                  },
+                  "labels": {
+                    "scope": "prod"
                   }
                 }
+              },
+              "labels": {
+                "scope": "prod"
               }
             }
+          },
+          "labels": {
+            "scope": "prod"
           }
         }
+      },
+      "labels": {
+        "scope": "prod"
       }
     }
   }

--- a/test/fixtures/circular_deps_special_test/composer_deps.json
+++ b/test/fixtures/circular_deps_special_test/composer_deps.json
@@ -7,7 +7,8 @@
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "symfony/polyfill-mbstring": {
       "name": "symfony/polyfill-mbstring",
@@ -20,12 +21,14 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "ext-phar": {
               "name": "ext-phar",
               "version": "*",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phar-io/version": {
               "name": "phar-io/version",
@@ -34,14 +37,17 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "okaufmann/swiss-weather-api": {
               "name": "okaufmann/swiss-weather-api",
@@ -58,9 +64,11 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "guzzlehttp/psr7": {
                       "name": "guzzlehttp/psr7",
@@ -69,7 +77,8 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "psr/http-message": {
                           "name": "psr/http-message",
@@ -78,18 +87,23 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "illuminate/support": {
                   "name": "illuminate/support",
@@ -102,14 +116,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "ext-mbstring": {
                       "name": "ext-mbstring",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "illuminate/contracts": {
                       "name": "illuminate/contracts",
@@ -118,7 +135,8 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "psr/container": {
                           "name": "psr/container",
@@ -127,9 +145,11 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "psr/simple-cache": {
                           "name": "psr/simple-cache",
@@ -138,11 +158,14 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "nesbot/carbon": {
                       "name": "nesbot/carbon",
@@ -151,7 +174,8 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "symfony/translation": {
                           "name": "symfony/translation",
@@ -160,23 +184,29 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "symfony/polyfill-mbstring": {
                               "name": "symfony/polyfill-mbstring",
                               "version": "1.6-dev",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "kevinrob/guzzle-cache-middleware": {
                   "name": "kevinrob/guzzle-cache-middleware",
@@ -185,14 +215,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "spatie/regex": {
                   "name": "spatie/regex",
@@ -201,9 +234,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "symfony/debug": {
                   "name": "symfony/debug",
@@ -212,7 +247,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "psr/log": {
                       "name": "psr/log",
@@ -221,9 +257,11 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "doctrine/instantiator": {
                       "name": "doctrine/instantiator",
@@ -232,20 +270,26 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "phar-io/manifest": {
                           "name": "phar-io/manifest",
                           "version": "1.0.x-dev",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/debug": {
           "name": "symfony/debug",
@@ -254,7 +298,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -263,9 +308,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "doctrine/instantiator": {
               "name": "doctrine/instantiator",
@@ -274,7 +321,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phar-io/manifest": {
                   "name": "phar-io/manifest",
@@ -283,12 +331,14 @@
                     "ext-dom": {
                       "name": "ext-dom",
                       "version": "20031129",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "ext-phar": {
                       "name": "ext-phar",
                       "version": "*",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "phar-io/version": {
                       "name": "phar-io/version",
@@ -297,14 +347,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "okaufmann/swiss-weather-api": {
                       "name": "okaufmann/swiss-weather-api",
@@ -321,9 +374,11 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "guzzlehttp/psr7": {
                               "name": "guzzlehttp/psr7",
@@ -332,7 +387,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/http-message": {
                                   "name": "psr/http-message",
@@ -341,18 +397,23 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "illuminate/support": {
                           "name": "illuminate/support",
@@ -365,14 +426,17 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "ext-mbstring": {
                               "name": "ext-mbstring",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "illuminate/contracts": {
                               "name": "illuminate/contracts",
@@ -381,7 +445,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/container": {
                                   "name": "psr/container",
@@ -390,9 +455,11 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/simple-cache": {
                                   "name": "psr/simple-cache",
@@ -401,11 +468,14 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "nesbot/carbon": {
                               "name": "nesbot/carbon",
@@ -414,7 +484,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "symfony/translation": {
                                   "name": "symfony/translation",
@@ -423,23 +494,29 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "symfony/polyfill-mbstring": {
                                       "name": "symfony/polyfill-mbstring",
                                       "version": "1.6-dev",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "kevinrob/guzzle-cache-middleware": {
                           "name": "kevinrob/guzzle-cache-middleware",
@@ -448,14 +525,17 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "spatie/regex": {
                           "name": "spatie/regex",
@@ -464,24 +544,32 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "symfony/debug": {
                           "name": "symfony/debug",
                           "version": "4.0-dev",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "symfony/debug": {
       "name": "symfony/debug",
@@ -490,7 +578,8 @@
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "psr/log": {
           "name": "psr/log",
@@ -499,9 +588,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "doctrine/instantiator": {
           "name": "doctrine/instantiator",
@@ -510,7 +601,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phar-io/manifest": {
               "name": "phar-io/manifest",
@@ -519,12 +611,14 @@
                 "ext-dom": {
                   "name": "ext-dom",
                   "version": "20031129",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "ext-phar": {
                   "name": "ext-phar",
                   "version": "*",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phar-io/version": {
                   "name": "phar-io/version",
@@ -533,14 +627,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "okaufmann/swiss-weather-api": {
                   "name": "okaufmann/swiss-weather-api",
@@ -557,9 +654,11 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "guzzlehttp/psr7": {
                           "name": "guzzlehttp/psr7",
@@ -568,7 +667,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "psr/http-message": {
                               "name": "psr/http-message",
@@ -577,18 +677,23 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "illuminate/support": {
                       "name": "illuminate/support",
@@ -601,14 +706,17 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "ext-mbstring": {
                           "name": "ext-mbstring",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "illuminate/contracts": {
                           "name": "illuminate/contracts",
@@ -617,7 +725,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "psr/container": {
                               "name": "psr/container",
@@ -626,9 +735,11 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "psr/simple-cache": {
                               "name": "psr/simple-cache",
@@ -637,11 +748,14 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "nesbot/carbon": {
                           "name": "nesbot/carbon",
@@ -650,7 +764,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "symfony/translation": {
                               "name": "symfony/translation",
@@ -659,7 +774,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "symfony/polyfill-mbstring": {
                                   "name": "symfony/polyfill-mbstring",
@@ -668,25 +784,32 @@
                                     "phar-io/manifest": {
                                       "name": "phar-io/manifest",
                                       "version": "1.0.x-dev",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "symfony/debug": {
                                       "name": "symfony/debug",
                                       "version": "4.0-dev",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "kevinrob/guzzle-cache-middleware": {
                       "name": "kevinrob/guzzle-cache-middleware",
@@ -695,14 +818,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "spatie/regex": {
                       "name": "spatie/regex",
@@ -711,27 +837,35 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "symfony/debug": {
                       "name": "symfony/debug",
                       "version": "4.0-dev",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "ext-dom": {
       "name": "ext-dom",
       "version": "20031129",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "phpunit/phpunit": {
       "name": "phpunit/phpunit",
@@ -740,27 +874,32 @@
         "ext-dom": {
           "name": "ext-dom",
           "version": "20031129",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-json": {
           "name": "ext-json",
           "version": "1.5.0",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-libxml": {
           "name": "ext-libxml",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-mbstring": {
           "name": "ext-mbstring",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-xml": {
           "name": "ext-xml",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "myclabs/deep-copy": {
           "name": "myclabs/deep-copy",
@@ -769,9 +908,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phar-io/manifest": {
           "name": "phar-io/manifest",
@@ -780,12 +921,14 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "ext-phar": {
               "name": "ext-phar",
               "version": "*",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phar-io/version": {
               "name": "phar-io/version",
@@ -794,14 +937,17 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "okaufmann/swiss-weather-api": {
               "name": "okaufmann/swiss-weather-api",
@@ -818,9 +964,11 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "guzzlehttp/psr7": {
                       "name": "guzzlehttp/psr7",
@@ -829,7 +977,8 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "psr/http-message": {
                           "name": "psr/http-message",
@@ -838,18 +987,23 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "illuminate/support": {
                   "name": "illuminate/support",
@@ -862,14 +1016,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "ext-mbstring": {
                       "name": "ext-mbstring",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "illuminate/contracts": {
                       "name": "illuminate/contracts",
@@ -878,7 +1035,8 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "psr/container": {
                           "name": "psr/container",
@@ -887,9 +1045,11 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "psr/simple-cache": {
                           "name": "psr/simple-cache",
@@ -898,11 +1058,14 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "nesbot/carbon": {
                       "name": "nesbot/carbon",
@@ -911,7 +1074,8 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "symfony/translation": {
                           "name": "symfony/translation",
@@ -920,7 +1084,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "symfony/polyfill-mbstring": {
                               "name": "symfony/polyfill-mbstring",
@@ -929,7 +1094,8 @@
                                 "phar-io/manifest": {
                                   "name": "phar-io/manifest",
                                   "version": "1.0.x-dev",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "symfony/debug": {
                                   "name": "symfony/debug",
@@ -938,7 +1104,8 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "psr/log": {
                                       "name": "psr/log",
@@ -947,9 +1114,11 @@
                                         "php": {
                                           "name": "php",
                                           "version": "7.1.12",
-                                          "dependencies": {}
+                                          "dependencies": {},
+                                          "labels": { "scope": "prod" }
                                         }
-                                      }
+                                      },
+                                      "labels": { "scope": "prod" }
                                     },
                                     "doctrine/instantiator": {
                                       "name": "doctrine/instantiator",
@@ -958,29 +1127,38 @@
                                         "php": {
                                           "name": "php",
                                           "version": "7.1.12",
-                                          "dependencies": {}
+                                          "dependencies": {},
+                                          "labels": { "scope": "prod" }
                                         },
                                         "phar-io/manifest": {
                                           "name": "phar-io/manifest",
                                           "version": "1.0.x-dev",
-                                          "dependencies": {}
+                                          "dependencies": {},
+                                          "labels": { "scope": "prod" }
                                         }
-                                      }
+                                      },
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "kevinrob/guzzle-cache-middleware": {
                   "name": "kevinrob/guzzle-cache-middleware",
@@ -989,14 +1167,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "spatie/regex": {
                   "name": "spatie/regex",
@@ -1005,9 +1186,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "symfony/debug": {
                   "name": "symfony/debug",
@@ -1016,7 +1199,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "psr/log": {
                       "name": "psr/log",
@@ -1025,9 +1209,11 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "doctrine/instantiator": {
                       "name": "doctrine/instantiator",
@@ -1036,20 +1222,26 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "phar-io/manifest": {
                           "name": "phar-io/manifest",
                           "version": "1.0.x-dev",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phar-io/version": {
           "name": "phar-io/version",
@@ -1058,14 +1250,17 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "phpspec/prophecy": {
           "name": "phpspec/prophecy",
@@ -1078,7 +1273,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phar-io/manifest": {
                   "name": "phar-io/manifest",
@@ -1087,12 +1283,14 @@
                     "ext-dom": {
                       "name": "ext-dom",
                       "version": "20031129",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "ext-phar": {
                       "name": "ext-phar",
                       "version": "*",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "phar-io/version": {
                       "name": "phar-io/version",
@@ -1101,14 +1299,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "okaufmann/swiss-weather-api": {
                       "name": "okaufmann/swiss-weather-api",
@@ -1125,9 +1326,11 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "guzzlehttp/psr7": {
                               "name": "guzzlehttp/psr7",
@@ -1136,7 +1339,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/http-message": {
                                   "name": "psr/http-message",
@@ -1145,18 +1349,23 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "illuminate/support": {
                           "name": "illuminate/support",
@@ -1169,14 +1378,17 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "ext-mbstring": {
                               "name": "ext-mbstring",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "illuminate/contracts": {
                               "name": "illuminate/contracts",
@@ -1185,7 +1397,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/container": {
                                   "name": "psr/container",
@@ -1194,9 +1407,11 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/simple-cache": {
                                   "name": "psr/simple-cache",
@@ -1205,11 +1420,14 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "nesbot/carbon": {
                               "name": "nesbot/carbon",
@@ -1218,7 +1436,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "symfony/translation": {
                                   "name": "symfony/translation",
@@ -1227,7 +1446,8 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "symfony/polyfill-mbstring": {
                                       "name": "symfony/polyfill-mbstring",
@@ -1236,7 +1456,8 @@
                                         "phar-io/manifest": {
                                           "name": "phar-io/manifest",
                                           "version": "1.0.x-dev",
-                                          "dependencies": {}
+                                          "dependencies": {},
+                                          "labels": { "scope": "prod" }
                                         },
                                         "symfony/debug": {
                                           "name": "symfony/debug",
@@ -1245,7 +1466,8 @@
                                             "php": {
                                               "name": "php",
                                               "version": "7.1.12",
-                                              "dependencies": {}
+                                              "dependencies": {},
+                                              "labels": { "scope": "prod" }
                                             },
                                             "psr/log": {
                                               "name": "psr/log",
@@ -1254,29 +1476,38 @@
                                                 "php": {
                                                   "name": "php",
                                                   "version": "7.1.12",
-                                                  "dependencies": {}
+                                                  "dependencies": {},
+                                                  "labels": { "scope": "prod" }
                                                 }
-                                              }
+                                              },
+                                              "labels": { "scope": "prod" }
                                             },
                                             "doctrine/instantiator": {
                                               "name": "doctrine/instantiator",
                                               "version": "1.2.x-dev",
-                                              "dependencies": {}
+                                              "dependencies": {},
+                                              "labels": { "scope": "prod" }
                                             }
-                                          }
+                                          },
+                                          "labels": { "scope": "prod" }
                                         }
-                                      }
+                                      },
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "kevinrob/guzzle-cache-middleware": {
                           "name": "kevinrob/guzzle-cache-middleware",
@@ -1285,14 +1516,17 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "spatie/regex": {
                           "name": "spatie/regex",
@@ -1301,9 +1535,11 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "symfony/debug": {
                           "name": "symfony/debug",
@@ -1312,7 +1548,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "psr/log": {
                               "name": "psr/log",
@@ -1321,27 +1558,35 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "doctrine/instantiator": {
                               "name": "doctrine/instantiator",
                               "version": "1.2.x-dev",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phpdocumentor/reflection-docblock": {
               "name": "phpdocumentor/reflection-docblock",
@@ -1350,7 +1595,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phpdocumentor/reflection-common": {
                   "name": "phpdocumentor/reflection-common",
@@ -1359,9 +1605,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "phpdocumentor/type-resolver": {
                   "name": "phpdocumentor/type-resolver",
@@ -1370,7 +1618,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "phpdocumentor/reflection-common": {
                       "name": "phpdocumentor/reflection-common",
@@ -1379,11 +1628,14 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "webmozart/assert": {
                   "name": "webmozart/assert",
@@ -1392,11 +1644,14 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/comparator": {
               "name": "sebastian/comparator",
@@ -1405,7 +1660,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/diff": {
                   "name": "sebastian/diff",
@@ -1414,9 +1670,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/exporter": {
                   "name": "sebastian/exporter",
@@ -1425,7 +1683,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "sebastian/recursion-context": {
                       "name": "sebastian/recursion-context",
@@ -1434,13 +1693,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/recursion-context": {
               "name": "sebastian/recursion-context",
@@ -1449,11 +1712,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-code-coverage": {
           "name": "phpunit/php-code-coverage",
@@ -1462,17 +1728,20 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "ext-xmlwriter": {
               "name": "ext-xmlwriter",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-file-iterator": {
               "name": "phpunit/php-file-iterator",
@@ -1481,9 +1750,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-text-template": {
               "name": "phpunit/php-text-template",
@@ -1492,9 +1763,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-token-stream": {
               "name": "phpunit/php-token-stream",
@@ -1503,14 +1776,17 @@
                 "ext-tokenizer": {
                   "name": "ext-tokenizer",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/code-unit-reverse-lookup": {
               "name": "sebastian/code-unit-reverse-lookup",
@@ -1519,9 +1795,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/environment": {
               "name": "sebastian/environment",
@@ -1530,9 +1808,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/version": {
               "name": "sebastian/version",
@@ -1541,9 +1821,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "theseer/tokenizer": {
               "name": "theseer/tokenizer",
@@ -1552,26 +1834,32 @@
                 "ext-dom": {
                   "name": "ext-dom",
                   "version": "20031129",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "ext-tokenizer": {
                   "name": "ext-tokenizer",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "ext-xmlwriter": {
                   "name": "ext-xmlwriter",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-file-iterator": {
           "name": "phpunit/php-file-iterator",
@@ -1580,9 +1868,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-text-template": {
           "name": "phpunit/php-text-template",
@@ -1591,9 +1881,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-timer": {
           "name": "phpunit/php-timer",
@@ -1602,9 +1894,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/phpunit-mock-objects": {
           "name": "phpunit/phpunit-mock-objects",
@@ -1617,7 +1911,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phar-io/manifest": {
                   "name": "phar-io/manifest",
@@ -1626,12 +1921,14 @@
                     "ext-dom": {
                       "name": "ext-dom",
                       "version": "20031129",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "ext-phar": {
                       "name": "ext-phar",
                       "version": "*",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "phar-io/version": {
                       "name": "phar-io/version",
@@ -1640,14 +1937,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "okaufmann/swiss-weather-api": {
                       "name": "okaufmann/swiss-weather-api",
@@ -1664,9 +1964,11 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "guzzlehttp/psr7": {
                               "name": "guzzlehttp/psr7",
@@ -1675,7 +1977,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/http-message": {
                                   "name": "psr/http-message",
@@ -1684,18 +1987,23 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "illuminate/support": {
                           "name": "illuminate/support",
@@ -1708,14 +2016,17 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "ext-mbstring": {
                               "name": "ext-mbstring",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "illuminate/contracts": {
                               "name": "illuminate/contracts",
@@ -1724,7 +2035,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/container": {
                                   "name": "psr/container",
@@ -1733,9 +2045,11 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 },
                                 "psr/simple-cache": {
                                   "name": "psr/simple-cache",
@@ -1744,11 +2058,14 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "nesbot/carbon": {
                               "name": "nesbot/carbon",
@@ -1757,7 +2074,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "symfony/translation": {
                                   "name": "symfony/translation",
@@ -1766,7 +2084,8 @@
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "symfony/polyfill-mbstring": {
                                       "name": "symfony/polyfill-mbstring",
@@ -1775,7 +2094,8 @@
                                         "phar-io/manifest": {
                                           "name": "phar-io/manifest",
                                           "version": "1.0.x-dev",
-                                          "dependencies": {}
+                                          "dependencies": {},
+                                          "labels": { "scope": "prod" }
                                         },
                                         "symfony/debug": {
                                           "name": "symfony/debug",
@@ -1784,7 +2104,8 @@
                                             "php": {
                                               "name": "php",
                                               "version": "7.1.12",
-                                              "dependencies": {}
+                                              "dependencies": {},
+                                              "labels": { "scope": "prod" }
                                             },
                                             "psr/log": {
                                               "name": "psr/log",
@@ -1793,29 +2114,38 @@
                                                 "php": {
                                                   "name": "php",
                                                   "version": "7.1.12",
-                                                  "dependencies": {}
+                                                  "dependencies": {},
+                                                  "labels": { "scope": "prod" }
                                                 }
-                                              }
+                                              },
+                                              "labels": { "scope": "prod" }
                                             },
                                             "doctrine/instantiator": {
                                               "name": "doctrine/instantiator",
                                               "version": "1.2.x-dev",
-                                              "dependencies": {}
+                                              "dependencies": {},
+                                              "labels": { "scope": "prod" }
                                             }
-                                          }
+                                          },
+                                          "labels": { "scope": "prod" }
                                         }
-                                      }
+                                      },
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "kevinrob/guzzle-cache-middleware": {
                           "name": "kevinrob/guzzle-cache-middleware",
@@ -1824,14 +2154,17 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         },
                         "spatie/regex": {
                           "name": "spatie/regex",
@@ -1840,9 +2173,11 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "symfony/debug": {
                           "name": "symfony/debug",
@@ -1851,7 +2186,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "psr/log": {
                               "name": "psr/log",
@@ -1860,27 +2196,35 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "doctrine/instantiator": {
                               "name": "doctrine/instantiator",
                               "version": "1.2.x-dev",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-text-template": {
               "name": "phpunit/php-text-template",
@@ -1889,9 +2233,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/exporter": {
               "name": "sebastian/exporter",
@@ -1900,7 +2246,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/recursion-context": {
                   "name": "sebastian/recursion-context",
@@ -1909,13 +2256,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/comparator": {
           "name": "sebastian/comparator",
@@ -1924,7 +2275,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "sebastian/diff": {
               "name": "sebastian/diff",
@@ -1933,9 +2285,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/exporter": {
               "name": "sebastian/exporter",
@@ -1944,7 +2298,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/recursion-context": {
                   "name": "sebastian/recursion-context",
@@ -1953,13 +2308,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/diff": {
           "name": "sebastian/diff",
@@ -1968,9 +2327,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/environment": {
           "name": "sebastian/environment",
@@ -1979,9 +2340,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/exporter": {
           "name": "sebastian/exporter",
@@ -1990,7 +2353,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "sebastian/recursion-context": {
               "name": "sebastian/recursion-context",
@@ -1999,11 +2363,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/global-state": {
           "name": "sebastian/global-state",
@@ -2012,9 +2379,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/object-enumerator": {
           "name": "sebastian/object-enumerator",
@@ -2023,7 +2392,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "sebastian/object-reflector": {
               "name": "sebastian/object-reflector",
@@ -2032,9 +2402,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/recursion-context": {
               "name": "sebastian/recursion-context",
@@ -2043,11 +2415,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/resource-operations": {
           "name": "sebastian/resource-operations",
@@ -2056,9 +2431,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/version": {
           "name": "sebastian/version",
@@ -2067,11 +2444,14 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "okaufmann/swiss-weather-api": {
       "name": "okaufmann/swiss-weather-api",
@@ -2088,9 +2468,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "guzzlehttp/psr7": {
               "name": "guzzlehttp/psr7",
@@ -2099,7 +2481,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/http-message": {
                   "name": "psr/http-message",
@@ -2108,18 +2491,23 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "illuminate/support": {
           "name": "illuminate/support",
@@ -2132,14 +2520,17 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "ext-mbstring": {
               "name": "ext-mbstring",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "illuminate/contracts": {
               "name": "illuminate/contracts",
@@ -2148,7 +2539,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/container": {
                   "name": "psr/container",
@@ -2157,9 +2549,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "psr/simple-cache": {
                   "name": "psr/simple-cache",
@@ -2168,11 +2562,14 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "nesbot/carbon": {
               "name": "nesbot/carbon",
@@ -2181,7 +2578,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "symfony/translation": {
                   "name": "symfony/translation",
@@ -2190,7 +2588,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "symfony/polyfill-mbstring": {
                       "name": "symfony/polyfill-mbstring",
@@ -2203,12 +2602,14 @@
                             "ext-dom": {
                               "name": "ext-dom",
                               "version": "20031129",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "ext-phar": {
                               "name": "ext-phar",
                               "version": "*",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "phar-io/version": {
                               "name": "phar-io/version",
@@ -2217,21 +2618,26 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "okaufmann/swiss-weather-api": {
                               "name": "okaufmann/swiss-weather-api",
                               "version": "0.0.6",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         },
                         "symfony/debug": {
                           "name": "symfony/debug",
@@ -2240,7 +2646,8 @@
                             "php": {
                               "name": "php",
                               "version": "7.1.12",
-                              "dependencies": {}
+                              "dependencies": {},
+                              "labels": { "scope": "prod" }
                             },
                             "psr/log": {
                               "name": "psr/log",
@@ -2249,9 +2656,11 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             },
                             "doctrine/instantiator": {
                               "name": "doctrine/instantiator",
@@ -2260,7 +2669,8 @@
                                 "php": {
                                   "name": "php",
                                   "version": "7.1.12",
-                                  "dependencies": {}
+                                  "dependencies": {},
+                                  "labels": { "scope": "prod" }
                                 },
                                 "phar-io/manifest": {
                                   "name": "phar-io/manifest",
@@ -2269,12 +2679,14 @@
                                     "ext-dom": {
                                       "name": "ext-dom",
                                       "version": "20031129",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "ext-phar": {
                                       "name": "ext-phar",
                                       "version": "*",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "phar-io/version": {
                                       "name": "phar-io/version",
@@ -2283,38 +2695,50 @@
                                         "php": {
                                           "name": "php",
                                           "version": "7.1.12",
-                                          "dependencies": {}
+                                          "dependencies": {},
+                                          "labels": { "scope": "prod" }
                                         }
-                                      }
+                                      },
+                                      "labels": { "scope": "prod" }
                                     },
                                     "php": {
                                       "name": "php",
                                       "version": "7.1.12",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     },
                                     "okaufmann/swiss-weather-api": {
                                       "name": "okaufmann/swiss-weather-api",
                                       "version": "0.0.6",
-                                      "dependencies": {}
+                                      "dependencies": {},
+                                      "labels": { "scope": "prod" }
                                     }
-                                  }
+                                  },
+                                  "labels": { "scope": "prod" }
                                 }
-                              }
+                              },
+                              "labels": { "scope": "prod" }
                             }
-                          }
+                          },
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "kevinrob/guzzle-cache-middleware": {
           "name": "kevinrob/guzzle-cache-middleware",
@@ -2323,14 +2747,17 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "spatie/regex": {
           "name": "spatie/regex",
@@ -2339,9 +2766,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/debug": {
           "name": "symfony/debug",
@@ -2350,7 +2779,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -2359,9 +2789,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "doctrine/instantiator": {
               "name": "doctrine/instantiator",
@@ -2370,7 +2802,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phar-io/manifest": {
                   "name": "phar-io/manifest",
@@ -2379,12 +2812,14 @@
                     "ext-dom": {
                       "name": "ext-dom",
                       "version": "20031129",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "ext-phar": {
                       "name": "ext-phar",
                       "version": "*",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "phar-io/version": {
                       "name": "phar-io/version",
@@ -2393,27 +2828,35 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     },
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "okaufmann/swiss-weather-api": {
                       "name": "okaufmann/swiss-weather-api",
                       "version": "0.0.6",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/lockfile_with_no_name_dep/composer.json
+++ b/test/fixtures/lockfile_with_no_name_dep/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "simple/hello-php",
+    "description": "Simple php application",
+    "type": "project",
+    "require-dev": {
+        "phpunit/phpunit": "^8.4"
+    },
+    "license": "Apache-2.0",
+    "require": {
+        "php": "^7.3",
+        "psr/log": "^1.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "": "src/"
+        }
+    },
+    "scripts": {
+        "tests": [
+            "phpunit tests/"
+        ]
+    }
+}

--- a/test/fixtures/lockfile_with_no_name_dep/composer.lock
+++ b/test/fixtures/lockfile_with_no_name_dep/composer.lock
@@ -1,0 +1,1584 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2faebd49decf63e629077005a55a4e29",
+    "packages": [
+        {
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2019-10-25T08:06:51+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-03-17T17:37:11+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2019-08-09T12:45:53+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2018-08-07T13:53:10+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2019-09-12T14:27:41+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2019-10-03T11:07:50+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "7.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "aa0d179a13284c7420fc281fc32750e6cc7c9e2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa0d179a13284c7420fc281fc32750e6cc7c9e2f",
+                "reference": "aa0d179a13284c7420fc281fc32750e6cc7c9e2f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2.2"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2019-09-17T06:24:36+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2018-09-13T20:33:42+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2019-06-07T04:22:29+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2019-09-17T06:23:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "8.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "366a4a0f2b971fd43b7c351d621e8dd7d7131869"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/366a4a0f2b971fd43b7c351d621e8dd7d7131869",
+                "reference": "366a4a0f2b971fd43b7c351d621e8dd7d7131869",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2019-10-07T12:57:41+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-07-12T15:12:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2019-02-04T06:01:07+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "4.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2019-05-05T09:05:15+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2019-09-14T09:02:43+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2019-02-01T05:30:01+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2019-08-24T08:43:50+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.3"
+    },
+    "platform-dev": []
+}

--- a/test/fixtures/lockfile_with_no_name_dep/composer_deps.json
+++ b/test/fixtures/lockfile_with_no_name_dep/composer_deps.json
@@ -9,6 +9,12 @@
       "version": "7.1.12",
       "dependencies": {},
       "labels": { "scope": "prod" }
+    },
+    "psr/log": {
+      "name": "psr/log",
+      "version": "^1.1",
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/many_deps_php_project/composer_deps.json
+++ b/test/fixtures/many_deps_php_project/composer_deps.json
@@ -2,12 +2,13 @@
   "name": "symfony/console",
   "version": "4.0-dev",
   "packageFormatVersion": "composer:0.0.1",
-  "hasDevDependencies": false,
+  "hasDevDependencies": true,
   "dependencies": {
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "symfony/polyfill-mbstring": {
       "name": "symfony/polyfill-mbstring",
@@ -16,9 +17,11 @@
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "symfony/debug": {
       "name": "symfony/debug",
@@ -27,7 +30,8 @@
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "psr/log": {
           "name": "psr/log",
@@ -36,16 +40,20 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "ext-dom": {
       "name": "ext-dom",
       "version": "20031129",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "phpunit/phpunit": {
       "name": "phpunit/phpunit",
@@ -54,27 +62,32 @@
         "ext-dom": {
           "name": "ext-dom",
           "version": "20031129",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-json": {
           "name": "ext-json",
           "version": "1.5.0",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-libxml": {
           "name": "ext-libxml",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-mbstring": {
           "name": "ext-mbstring",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "ext-xml": {
           "name": "ext-xml",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "myclabs/deep-copy": {
           "name": "myclabs/deep-copy",
@@ -83,9 +96,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phar-io/manifest": {
           "name": "phar-io/manifest",
@@ -94,12 +109,14 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "ext-phar": {
               "name": "ext-phar",
               "version": "*",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phar-io/version": {
               "name": "phar-io/version",
@@ -108,16 +125,20 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phar-io/version": {
           "name": "phar-io/version",
@@ -126,14 +147,17 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "phpspec/prophecy": {
           "name": "phpspec/prophecy",
@@ -146,14 +170,17 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phpdocumentor/reflection-docblock": {
               "name": "phpdocumentor/reflection-docblock",
@@ -162,7 +189,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "phpdocumentor/reflection-common": {
                   "name": "phpdocumentor/reflection-common",
@@ -171,9 +199,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "phpdocumentor/type-resolver": {
                   "name": "phpdocumentor/type-resolver",
@@ -182,7 +212,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "phpdocumentor/reflection-common": {
                       "name": "phpdocumentor/reflection-common",
@@ -191,11 +222,14 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "webmozart/assert": {
                   "name": "webmozart/assert",
@@ -204,11 +238,14 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/comparator": {
               "name": "sebastian/comparator",
@@ -217,7 +254,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/diff": {
                   "name": "sebastian/diff",
@@ -226,9 +264,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/exporter": {
                   "name": "sebastian/exporter",
@@ -237,7 +277,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "sebastian/recursion-context": {
                       "name": "sebastian/recursion-context",
@@ -246,13 +287,17 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/recursion-context": {
               "name": "sebastian/recursion-context",
@@ -261,11 +306,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-code-coverage": {
           "name": "phpunit/php-code-coverage",
@@ -274,17 +322,20 @@
             "ext-dom": {
               "name": "ext-dom",
               "version": "20031129",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "ext-xmlwriter": {
               "name": "ext-xmlwriter",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-file-iterator": {
               "name": "phpunit/php-file-iterator",
@@ -293,9 +344,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-text-template": {
               "name": "phpunit/php-text-template",
@@ -304,9 +357,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-token-stream": {
               "name": "phpunit/php-token-stream",
@@ -315,14 +370,17 @@
                 "ext-tokenizer": {
                   "name": "ext-tokenizer",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/code-unit-reverse-lookup": {
               "name": "sebastian/code-unit-reverse-lookup",
@@ -331,9 +389,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/environment": {
               "name": "sebastian/environment",
@@ -342,9 +402,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/version": {
               "name": "sebastian/version",
@@ -353,9 +415,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "theseer/tokenizer": {
               "name": "theseer/tokenizer",
@@ -364,26 +428,32 @@
                 "ext-dom": {
                   "name": "ext-dom",
                   "version": "20031129",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "ext-tokenizer": {
                   "name": "ext-tokenizer",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "ext-xmlwriter": {
                   "name": "ext-xmlwriter",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-file-iterator": {
           "name": "phpunit/php-file-iterator",
@@ -392,9 +462,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-text-template": {
           "name": "phpunit/php-text-template",
@@ -403,9 +475,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/php-timer": {
           "name": "phpunit/php-timer",
@@ -414,9 +488,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "phpunit/phpunit-mock-objects": {
           "name": "phpunit/phpunit-mock-objects",
@@ -429,14 +505,17 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "phpunit/php-text-template": {
               "name": "phpunit/php-text-template",
@@ -445,9 +524,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/exporter": {
               "name": "sebastian/exporter",
@@ -456,7 +537,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/recursion-context": {
                   "name": "sebastian/recursion-context",
@@ -465,13 +547,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/comparator": {
           "name": "sebastian/comparator",
@@ -480,7 +566,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "sebastian/diff": {
               "name": "sebastian/diff",
@@ -489,9 +576,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/exporter": {
               "name": "sebastian/exporter",
@@ -500,7 +589,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "sebastian/recursion-context": {
                   "name": "sebastian/recursion-context",
@@ -509,13 +599,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/diff": {
           "name": "sebastian/diff",
@@ -524,9 +618,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/environment": {
           "name": "sebastian/environment",
@@ -535,9 +631,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/exporter": {
           "name": "sebastian/exporter",
@@ -546,7 +644,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "sebastian/recursion-context": {
               "name": "sebastian/recursion-context",
@@ -555,11 +654,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/global-state": {
           "name": "sebastian/global-state",
@@ -568,9 +670,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/object-enumerator": {
           "name": "sebastian/object-enumerator",
@@ -579,7 +683,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "sebastian/object-reflector": {
               "name": "sebastian/object-reflector",
@@ -588,9 +693,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "sebastian/recursion-context": {
               "name": "sebastian/recursion-context",
@@ -599,11 +706,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/resource-operations": {
           "name": "sebastian/resource-operations",
@@ -612,9 +722,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "sebastian/version": {
           "name": "sebastian/version",
@@ -623,11 +735,14 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "okaufmann/swiss-weather-api": {
       "name": "okaufmann/swiss-weather-api",
@@ -644,9 +759,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "guzzlehttp/psr7": {
               "name": "guzzlehttp/psr7",
@@ -655,7 +772,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/http-message": {
                   "name": "psr/http-message",
@@ -664,18 +782,23 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "illuminate/support": {
           "name": "illuminate/support",
@@ -688,14 +811,17 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "ext-mbstring": {
               "name": "ext-mbstring",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "illuminate/contracts": {
               "name": "illuminate/contracts",
@@ -704,7 +830,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/container": {
                   "name": "psr/container",
@@ -713,9 +840,11 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "psr/simple-cache": {
                   "name": "psr/simple-cache",
@@ -724,11 +853,14 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "nesbot/carbon": {
               "name": "nesbot/carbon",
@@ -737,7 +869,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "symfony/translation": {
                   "name": "symfony/translation",
@@ -746,7 +879,8 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     },
                     "symfony/polyfill-mbstring": {
                       "name": "symfony/polyfill-mbstring",
@@ -755,20 +889,26 @@
                         "php": {
                           "name": "php",
                           "version": "7.1.12",
-                          "dependencies": {}
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
                         }
-                      }
+                      },
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "kevinrob/guzzle-cache-middleware": {
           "name": "kevinrob/guzzle-cache-middleware",
@@ -777,14 +917,17 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "spatie/regex": {
           "name": "spatie/regex",
@@ -793,11 +936,14 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/no_branch_alias/composer_deps.json
+++ b/test/fixtures/no_branch_alias/composer_deps.json
@@ -7,7 +7,8 @@
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "josantonius/router": {
       "name": "josantonius/router",
@@ -20,16 +21,20 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/proj_with_aliases/composer_deps.json
+++ b/test/fixtures/proj_with_aliases/composer_deps.json
@@ -7,7 +7,8 @@
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "symfony/monolog-bundle": {
       "name": "symfony/monolog-bundle",
@@ -20,7 +21,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -29,16 +31,20 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "symfony/config": {
           "name": "symfony/config",
@@ -47,7 +53,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "symfony/filesystem": {
               "name": "symfony/filesystem",
@@ -56,11 +63,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/dependency-injection": {
           "name": "symfony/dependency-injection",
@@ -69,7 +79,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/container": {
               "name": "psr/container",
@@ -78,11 +89,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/http-kernel": {
           "name": "symfony/http-kernel",
@@ -91,7 +105,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -100,9 +115,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "symfony/debug": {
               "name": "symfony/debug",
@@ -111,7 +128,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/log": {
                   "name": "psr/log",
@@ -120,11 +138,14 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "symfony/event-dispatcher": {
               "name": "symfony/event-dispatcher",
@@ -133,9 +154,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "symfony/http-foundation": {
               "name": "symfony/http-foundation",
@@ -144,7 +167,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "symfony/polyfill-mbstring": {
                   "name": "symfony/polyfill-mbstring",
@@ -153,13 +177,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/monolog-bridge": {
           "name": "symfony/monolog-bridge",
@@ -172,7 +200,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/log": {
                   "name": "psr/log",
@@ -181,20 +210,26 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "symfony/monolog-bridge": {
       "name": "symfony/monolog-bridge",
@@ -207,7 +242,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -216,18 +252,23 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/proj_with_aliases_external_github/composer_deps.json
+++ b/test/fixtures/proj_with_aliases_external_github/composer_deps.json
@@ -7,7 +7,8 @@
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "symfony/monolog-bundle": {
       "name": "symfony/monolog-bundle",
@@ -20,7 +21,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -29,16 +31,20 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "symfony/config": {
           "name": "symfony/config",
@@ -47,7 +53,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "symfony/filesystem": {
               "name": "symfony/filesystem",
@@ -56,11 +63,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/dependency-injection": {
           "name": "symfony/dependency-injection",
@@ -69,7 +79,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/container": {
               "name": "psr/container",
@@ -78,11 +89,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/http-kernel": {
           "name": "symfony/http-kernel",
@@ -91,7 +105,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -100,9 +115,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "symfony/debug": {
               "name": "symfony/debug",
@@ -111,7 +128,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/log": {
                   "name": "psr/log",
@@ -120,11 +138,14 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "symfony/event-dispatcher": {
               "name": "symfony/event-dispatcher",
@@ -133,9 +154,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "symfony/http-foundation": {
               "name": "symfony/http-foundation",
@@ -144,7 +167,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "symfony/polyfill-mbstring": {
                   "name": "symfony/polyfill-mbstring",
@@ -153,13 +177,17 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/monolog-bridge": {
           "name": "symfony/monolog-bridge",
@@ -172,7 +200,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/log": {
                   "name": "psr/log",
@@ -181,20 +210,26 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "symfony/monolog-bridge": {
       "name": "symfony/monolog-bridge",
@@ -207,7 +242,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/log": {
               "name": "psr/log",
@@ -216,18 +252,23 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/proj_with_dev_deps/composer_deps_with_dev.json
+++ b/test/fixtures/proj_with_dev_deps/composer_deps_with_dev.json
@@ -1,0 +1,1136 @@
+{
+  "name": "simple/hello-php",
+  "version": "0.0.0",
+  "packageFormatVersion": "composer:0.0.1",
+  "hasDevDependencies": true,
+  "dependencies": {
+    "php": {
+      "name": "php",
+      "version": "7.1.12",
+      "dependencies": {},
+      "labels": { "scope": "prod" }
+    },
+    "phpunit/phpunit": {
+      "name": "phpunit/phpunit",
+      "version": "8.4.1",
+      "dependencies": {
+        "doctrine/instantiator": {
+          "name": "doctrine/instantiator",
+          "version": "1.2.0",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "doctrine/coding-standard": {
+              "name": "doctrine/coding-standard",
+              "version": "^6.0",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "ext-pdo": {
+              "name": "ext-pdo",
+              "version": "*",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "ext-phar": {
+              "name": "ext-phar",
+              "version": "*",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpbench/phpbench": {
+              "name": "phpbench/phpbench",
+              "version": "^0.13",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpstan/phpstan-phpunit": {
+              "name": "phpstan/phpstan-phpunit",
+              "version": "^0.11",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpstan/phpstan-shim": {
+              "name": "phpstan/phpstan-shim",
+              "version": "^0.11",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "ext-dom": {
+          "name": "ext-dom",
+          "version": "20031129",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "ext-json": {
+          "name": "ext-json",
+          "version": "1.5.0",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "ext-libxml": {
+          "name": "ext-libxml",
+          "version": "7.1.12",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "ext-mbstring": {
+          "name": "ext-mbstring",
+          "version": "7.1.12",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "ext-xml": {
+          "name": "ext-xml",
+          "version": "7.1.12",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "ext-xmlwriter": {
+          "name": "ext-xmlwriter",
+          "version": "7.1.12",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "myclabs/deep-copy": {
+          "name": "myclabs/deep-copy",
+          "version": "1.9.3",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "doctrine/collections": {
+              "name": "doctrine/collections",
+              "version": "^1.0",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "doctrine/common": {
+              "name": "doctrine/common",
+              "version": "^2.6",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "phar-io/manifest": {
+          "name": "phar-io/manifest",
+          "version": "1.0.3",
+          "dependencies": {
+            "ext-dom": {
+              "name": "ext-dom",
+              "version": "20031129",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "ext-phar": {
+              "name": "ext-phar",
+              "version": "*",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phar-io/version": {
+              "name": "phar-io/version",
+              "version": "2.0.1",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "phar-io/version": {
+          "name": "phar-io/version",
+          "version": "2.0.1",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "php": {
+          "name": "php",
+          "version": "7.1.12",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        },
+        "phpspec/prophecy": {
+          "name": "phpspec/prophecy",
+          "version": "1.9.0",
+          "dependencies": {
+            "doctrine/instantiator": {
+              "name": "doctrine/instantiator",
+              "version": "1.2.0",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "doctrine/coding-standard": {
+                  "name": "doctrine/coding-standard",
+                  "version": "^6.0",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "ext-pdo": {
+                  "name": "ext-pdo",
+                  "version": "*",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "ext-phar": {
+                  "name": "ext-phar",
+                  "version": "*",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "phpbench/phpbench": {
+                  "name": "phpbench/phpbench",
+                  "version": "^0.13",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "phpstan/phpstan-phpunit": {
+                  "name": "phpstan/phpstan-phpunit",
+                  "version": "^0.11",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "phpstan/phpstan-shim": {
+                  "name": "phpstan/phpstan-shim",
+                  "version": "^0.11",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpdocumentor/reflection-docblock": {
+              "name": "phpdocumentor/reflection-docblock",
+              "version": "4.3.2",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpdocumentor/reflection-common": {
+                  "name": "phpdocumentor/reflection-common",
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "prod" }
+                },
+                "phpdocumentor/type-resolver": {
+                  "name": "phpdocumentor/type-resolver",
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
+                    },
+                    "phpdocumentor/reflection-common": {
+                      "name": "phpdocumentor/reflection-common",
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "php": {
+                          "name": "php",
+                          "version": "7.1.12",
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
+                        },
+                        "phpunit/phpunit": {
+                          "name": "phpunit/phpunit",
+                          "version": "8.4.1",
+                          "dependencies": {},
+                          "labels": { "scope": "dev" }
+                        }
+                      },
+                      "labels": { "scope": "prod" }
+                    },
+                    "ext-tokenizer": {
+                      "name": "ext-tokenizer",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "mockery/mockery": {
+                      "name": "mockery/mockery",
+                      "version": "~1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "prod" }
+                },
+                "webmozart/assert": {
+                  "name": "webmozart/assert",
+                  "version": "1.5.0",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
+                    },
+                    "symfony/polyfill-ctype": {
+                      "name": "symfony/polyfill-ctype",
+                      "version": "1.12.0",
+                      "dependencies": {
+                        "php": {
+                          "name": "php",
+                          "version": "7.1.12",
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
+                        }
+                      },
+                      "labels": { "scope": "prod" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "prod" }
+                },
+                "doctrine/instantiator": {
+                  "name": "doctrine/instantiator",
+                  "version": "1.2.0",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "doctrine/coding-standard": {
+                      "name": "doctrine/coding-standard",
+                      "version": "^6.0",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "ext-pdo": {
+                      "name": "ext-pdo",
+                      "version": "*",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "ext-phar": {
+                      "name": "ext-phar",
+                      "version": "*",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "phpbench/phpbench": {
+                      "name": "phpbench/phpbench",
+                      "version": "^0.13",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "phpstan/phpstan-phpunit": {
+                      "name": "phpstan/phpstan-phpunit",
+                      "version": "^0.11",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "phpstan/phpstan-shim": {
+                      "name": "phpstan/phpstan-shim",
+                      "version": "^0.11",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "dev" }
+                },
+                "mockery/mockery": {
+                  "name": "mockery/mockery",
+                  "version": "^1.0",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/comparator": {
+              "name": "sebastian/comparator",
+              "version": "3.0.2",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "sebastian/diff": {
+                  "name": "sebastian/diff",
+                  "version": "3.0.2",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "symfony/process": {
+                      "name": "symfony/process",
+                      "version": "^2 || ^3.3 || ^4",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "prod" }
+                },
+                "sebastian/exporter": {
+                  "name": "sebastian/exporter",
+                  "version": "3.1.2",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
+                    },
+                    "sebastian/recursion-context": {
+                      "name": "sebastian/recursion-context",
+                      "version": "3.0.0",
+                      "dependencies": {
+                        "php": {
+                          "name": "php",
+                          "version": "7.1.12",
+                          "dependencies": {},
+                          "labels": { "scope": "prod" }
+                        },
+                        "phpunit/phpunit": {
+                          "name": "phpunit/phpunit",
+                          "version": "8.4.1",
+                          "dependencies": {},
+                          "labels": { "scope": "dev" }
+                        }
+                      },
+                      "labels": { "scope": "prod" }
+                    },
+                    "ext-mbstring": {
+                      "name": "ext-mbstring",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/recursion-context": {
+              "name": "sebastian/recursion-context",
+              "version": "3.0.0",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "phpspec/phpspec": {
+              "name": "phpspec/phpspec",
+              "version": "^2.5|^3.2",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "phpunit/php-code-coverage": {
+          "name": "phpunit/php-code-coverage",
+          "version": "7.0.8",
+          "dependencies": {
+            "ext-dom": {
+              "name": "ext-dom",
+              "version": "20031129",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "ext-xmlwriter": {
+              "name": "ext-xmlwriter",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/php-file-iterator": {
+              "name": "phpunit/php-file-iterator",
+              "version": "2.0.2",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/php-text-template": {
+              "name": "phpunit/php-text-template",
+              "version": "1.2.1",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/php-token-stream": {
+              "name": "phpunit/php-token-stream",
+              "version": "3.1.1",
+              "dependencies": {
+                "ext-tokenizer": {
+                  "name": "ext-tokenizer",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/code-unit-reverse-lookup": {
+              "name": "sebastian/code-unit-reverse-lookup",
+              "version": "1.0.1",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/environment": {
+              "name": "sebastian/environment",
+              "version": "4.2.2",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/version": {
+              "name": "sebastian/version",
+              "version": "2.0.1",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "theseer/tokenizer": {
+              "name": "theseer/tokenizer",
+              "version": "1.1.3",
+              "dependencies": {
+                "ext-dom": {
+                  "name": "ext-dom",
+                  "version": "20031129",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "ext-tokenizer": {
+                  "name": "ext-tokenizer",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "ext-xmlwriter": {
+                  "name": "ext-xmlwriter",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "phpunit/php-file-iterator": {
+          "name": "phpunit/php-file-iterator",
+          "version": "2.0.2",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "phpunit/php-text-template": {
+          "name": "phpunit/php-text-template",
+          "version": "1.2.1",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "phpunit/php-timer": {
+          "name": "phpunit/php-timer",
+          "version": "2.1.2",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/comparator": {
+          "name": "sebastian/comparator",
+          "version": "3.0.2",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/diff": {
+              "name": "sebastian/diff",
+              "version": "3.0.2",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "symfony/process": {
+                  "name": "symfony/process",
+                  "version": "^2 || ^3.3 || ^4",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/exporter": {
+              "name": "sebastian/exporter",
+              "version": "3.1.2",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "sebastian/recursion-context": {
+                  "name": "sebastian/recursion-context",
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "php": {
+                      "name": "php",
+                      "version": "7.1.12",
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
+                    },
+                    "phpunit/phpunit": {
+                      "name": "phpunit/phpunit",
+                      "version": "8.4.1",
+                      "dependencies": {},
+                      "labels": { "scope": "dev" }
+                    }
+                  },
+                  "labels": { "scope": "prod" }
+                },
+                "ext-mbstring": {
+                  "name": "ext-mbstring",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/diff": {
+          "name": "sebastian/diff",
+          "version": "3.0.2",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "symfony/process": {
+              "name": "symfony/process",
+              "version": "^2 || ^3.3 || ^4",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/environment": {
+          "name": "sebastian/environment",
+          "version": "4.2.2",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/exporter": {
+          "name": "sebastian/exporter",
+          "version": "3.1.2",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/recursion-context": {
+              "name": "sebastian/recursion-context",
+              "version": "3.0.0",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "ext-mbstring": {
+              "name": "ext-mbstring",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/global-state": {
+          "name": "sebastian/global-state",
+          "version": "3.0.0",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/object-reflector": {
+              "name": "sebastian/object-reflector",
+              "version": "1.1.1",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/recursion-context": {
+              "name": "sebastian/recursion-context",
+              "version": "3.0.0",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "ext-dom": {
+              "name": "ext-dom",
+              "version": "20031129",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/object-enumerator": {
+          "name": "sebastian/object-enumerator",
+          "version": "3.0.3",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/object-reflector": {
+              "name": "sebastian/object-reflector",
+              "version": "1.1.1",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "sebastian/recursion-context": {
+              "name": "sebastian/recursion-context",
+              "version": "3.0.0",
+              "dependencies": {
+                "php": {
+                  "name": "php",
+                  "version": "7.1.12",
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
+                },
+                "phpunit/phpunit": {
+                  "name": "phpunit/phpunit",
+                  "version": "8.4.1",
+                  "dependencies": {},
+                  "labels": { "scope": "dev" }
+                }
+              },
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/resource-operations": {
+          "name": "sebastian/resource-operations",
+          "version": "2.0.1",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/type": {
+          "name": "sebastian/type",
+          "version": "1.1.3",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            },
+            "phpunit/phpunit": {
+              "name": "phpunit/phpunit",
+              "version": "8.4.1",
+              "dependencies": {},
+              "labels": { "scope": "dev" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "sebastian/version": {
+          "name": "sebastian/version",
+          "version": "2.0.1",
+          "dependencies": {
+            "php": {
+              "name": "php",
+              "version": "7.1.12",
+              "dependencies": {},
+              "labels": { "scope": "prod" }
+            }
+          },
+          "labels": { "scope": "dev" }
+        },
+        "ext-pdo": {
+          "name": "ext-pdo",
+          "version": "*",
+          "dependencies": {},
+          "labels": { "scope": "dev" }
+        }
+      },
+      "labels": { "scope": "dev" }
+    }
+  }
+}

--- a/test/fixtures/proj_with_no_deps/composer_deps.json
+++ b/test/fixtures/proj_with_no_deps/composer_deps.json
@@ -7,7 +7,8 @@
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/fixtures/vulnerable_project/composer_deps.json
+++ b/test/fixtures/vulnerable_project/composer_deps.json
@@ -7,7 +7,8 @@
     "php": {
       "name": "php",
       "version": "7.1.12",
-      "dependencies": {}
+      "dependencies": {},
+      "labels": { "scope": "prod" }
     },
     "symfony/symfony": {
       "name": "symfony/symfony",
@@ -28,16 +29,20 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 },
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "doctrine/cache": {
               "name": "doctrine/cache",
@@ -46,9 +51,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "doctrine/collections": {
               "name": "doctrine/collections",
@@ -57,9 +64,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "doctrine/inflector": {
               "name": "doctrine/inflector",
@@ -68,9 +77,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "doctrine/lexer": {
               "name": "doctrine/lexer",
@@ -79,21 +90,26 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         },
         "psr/log": {
           "name": "psr/log",
@@ -102,9 +118,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "symfony/icu": {
           "name": "symfony/icu",
@@ -113,24 +131,29 @@
             "ext-intl": {
               "name": "ext-intl",
               "version": "1.1.0",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "lib-icu": {
               "name": "lib-icu",
               "version": ">=4.4",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "symfony/intl": {
               "name": "symfony/intl",
               "version": "~2.3",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "twig/twig": {
           "name": "twig/twig",
@@ -139,11 +162,14 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "yiisoft/yii": {
       "name": "yiisoft/yii",
@@ -152,9 +178,11 @@
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "zendframework/zendframework": {
       "name": "zendframework/zendframework",
@@ -163,9 +191,11 @@
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "aws/aws-sdk-php": {
       "name": "aws/aws-sdk-php",
@@ -182,9 +212,11 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "guzzlehttp/psr7": {
               "name": "guzzlehttp/psr7",
@@ -193,7 +225,8 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 },
                 "psr/http-message": {
                   "name": "psr/http-message",
@@ -202,18 +235,23 @@
                     "php": {
                       "name": "php",
                       "version": "7.1.12",
-                      "dependencies": {}
+                      "dependencies": {},
+                      "labels": { "scope": "prod" }
                     }
-                  }
+                  },
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "guzzlehttp/promises": {
           "name": "guzzlehttp/promises",
@@ -222,9 +260,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "guzzlehttp/psr7": {
           "name": "guzzlehttp/psr7",
@@ -233,7 +273,8 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             },
             "psr/http-message": {
               "name": "psr/http-message",
@@ -242,11 +283,14 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "mtdowling/jmespath.php": {
           "name": "mtdowling/jmespath.php",
@@ -255,16 +299,20 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     },
     "doctrine/common": {
       "name": "doctrine/common",
@@ -281,16 +329,20 @@
                 "php": {
                   "name": "php",
                   "version": "7.1.12",
-                  "dependencies": {}
+                  "dependencies": {},
+                  "labels": { "scope": "prod" }
                 }
-              }
+              },
+              "labels": { "scope": "prod" }
             },
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "doctrine/cache": {
           "name": "doctrine/cache",
@@ -299,9 +351,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "doctrine/collections": {
           "name": "doctrine/collections",
@@ -310,9 +364,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "doctrine/inflector": {
           "name": "doctrine/inflector",
@@ -321,9 +377,11 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "doctrine/lexer": {
           "name": "doctrine/lexer",
@@ -332,16 +390,20 @@
             "php": {
               "name": "php",
               "version": "7.1.12",
-              "dependencies": {}
+              "dependencies": {},
+              "labels": { "scope": "prod" }
             }
-          }
+          },
+          "labels": { "scope": "prod" }
         },
         "php": {
           "name": "php",
           "version": "7.1.12",
-          "dependencies": {}
+          "dependencies": {},
+          "labels": { "scope": "prod" }
         }
-      }
+      },
+      "labels": { "scope": "prod" }
     }
   }
 }

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -16,6 +16,7 @@ const deepTestFolders = [
   'proj_with_aliases',
   'proj_with_aliases_external_github',
   'no_branch_alias',
+  'lockfile_with_no_name_dep',
 ];
 
 deepTestFolders.forEach((folder) => {
@@ -32,7 +33,7 @@ deepTestFolders.forEach((folder) => {
         test.end();
       });
     } catch (err) {
-      /* do nothing */
+      t.fail('Unexpected Error', err);
     }
   });
 });
@@ -47,7 +48,21 @@ tap.test('dev dependencies are not parsed by default', async (t) => {
       test.end();
     });
   } catch (err) {
-    t.fail('Unexpected error', err);
+    t.fail('Unexpected Error', err);
+  }
+});
+
+tap.test('dev dependencies are parsed when include dev true', async (t) => {
+  const projFolder = './test/fixtures/proj_with_dev_deps';
+  try {
+    const depTree = buildDepTreeFromFiles(projFolder, './composer.lock', systemVersionsStub, true);
+    t.test('match packages with expected', (test) => {
+      const expTree = JSON.parse(fs.readFileSync(path.resolve(projFolder, 'composer_deps_with_dev.json'), 'utf-8'));
+      test.deepEqual(depTree, expTree);
+      test.end();
+    });
+  } catch (err) {
+    t.fail('Unexpected Error', err);
   }
 });
 
@@ -157,13 +172,13 @@ tap.test('composer parser for project with many deps', async (t) => {
         name: 'symfony/console',
         version: '4.0-dev',
         packageFormatVersion: 'composer:0.0.1',
-        hasDevDependencies: false,
+        hasDevDependencies: true,
       }, 'root pkg');
 
       test.end();
     });
   } catch (err) {
-    /* do nothing */
+    t.fail('Unexpected Error', err);
   }
 });
 
@@ -187,7 +202,7 @@ tap.test('composer parser for project with interconnected deps', async (t) => {
       test.end();
     });
   } catch (err) {
-    /* do nothing */
+    t.fail('Unexpected Error', err);
   }
 });
 
@@ -208,7 +223,7 @@ tap.test('with alias, uses correct version', async (t) => {
       test.end();
     });
   } catch (err) {
-    /* do nothing */
+    t.fail('Unexpected Error', err);
   }
 });
 
@@ -255,7 +270,11 @@ tap.test('with alias in external repo', async (t) => {
         'there should be a url subproperty');
       test.equal(composerJson.repositories[0].type, 'vcs', 'there should be a type subproperty');
       // the alias is a branch
-      test.equal(aliasBranch, ourAliasBranchName, 'alias branch not found on remote github');
+      test.equal(
+        aliasBranch,
+        ourAliasBranchName,
+        `alias branch not found on remote github, ${aliasBranch} != ${ourAliasBranchName}`,
+      );
       test.end();
     });
 
@@ -269,7 +288,7 @@ tap.test('with alias in external repo', async (t) => {
       test.end();
     });
   } catch (err) {
-    /* do nothing */
+    t.fail('Unexpected Error', err);
   }
 });
 
@@ -286,6 +305,6 @@ tap.test('project name is not empty', async (t) => {
 
     t.end();
   } catch (err) {
-    /* do nothing */
+    t.fail('Unexpected Error', err);
   }
 });


### PR DESCRIPTION
BST-916

Refactored buildDependencies to have all recursion logic in one place
Added loop over dev packages
Added scope to return object, packages now have either 'prod' or
'dev' labels
Updated test fixtures
Added test for dev dependencies

- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Adds ability to parse dev packages from php compser project.

#### How should this be manually tested?

npm test

#### What are the relevant tickets?

BST-916
