### PR TITLE
fix: use bin and dist folders only when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "bin",
+    "dist"
+  ],
   "keywords": [
     "snyk",
     "php",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Add files configuration to package.json to only include bin and dist folders when publishing this package. Excludes any other directory, like test fixtures.

#### What are the relevant tickets?

https://github.com/snyk/composer-lockfile-parser/issues/13
