### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "node-fetch": "^2.6.0",
     "tap": "12.7.0",
     "tslint": "5.17.0",
-    "typescript": "3.5.1"
+    "typescript": "3.7.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es5",
-        "lib": ["es5", "es2015.promise"],
+        "target": "es2015",
+        "lib": ["es2015"],
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
#### What does this PR do?

Stop generating legacy code; node 6 (the minimum thing we support) supports es2015 fine.