### PR TITLE
fix: switch to lodash 'dot' packages

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as _ from '@snyk/lodash';
+import * as _isEmpty from 'lodash.isempty';
 import * as path from 'path';
 
 import { InvalidUserInputError } from './errors';
@@ -31,7 +31,7 @@ function buildDepTree(
     systemVersions,
     includeDev,
   );
-  const hasDevDependencies = !_.isEmpty(manifestJson['require-dev']);
+  const hasDevDependencies = !_isEmpty(manifestJson['require-dev']);
 
   return {
     name,

--- a/lib/parsers/composer-parser.ts
+++ b/lib/parsers/composer-parser.ts
@@ -1,4 +1,7 @@
-import * as _ from '@snyk/lodash';
+import * as _findKey from 'lodash.findkey';
+import * as _get from 'lodash.get';
+import * as _invert from 'lodash.invert';
+import * as _isEmpty from 'lodash.isempty';
 
 import {
   SystemPackages,
@@ -9,6 +12,13 @@ import {
   DepTreeDependencies,
   Scope,
 } from '../types';
+
+const _ = {
+  get: _get,
+  isEmpty: _isEmpty,
+  invert: _invert,
+  findKey: _findKey,
+};
 
 export class ComposerParser {
   // After this threshold, a package node in the dep tree won't have expanded dependencies.

--- a/package.json
+++ b/package.json
@@ -35,11 +35,15 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/lodash": "^4.17.15-patch"
+    "lodash.findkey": "^4.6.0",
+    "lodash.get": "^4.4.2",
+    "lodash.invert": "^4.3.0",
+    "lodash.isempty": "^4.4.0"
   },
   "devDependencies": {
     "@types/node": "6.14.6",
     "@types/node-fetch": "^2.5.2",
+    "lodash.find": "^4.6.0",
     "node-fetch": "^2.6.0",
     "tap": "12.7.0",
     "tslint": "5.17.0",

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -1,11 +1,17 @@
 import * as fs from 'fs';
 import * as tap from 'tap';
-import * as _ from '@snyk/lodash';
+import * as _get from 'lodash.get';
+import * as _find from 'lodash.find';
 import * as path from 'path';
 import fetch from 'node-fetch';
 
 import { buildDepTreeFromFiles } from '../lib';
 import { systemVersionsStub } from './stubs/system_deps_stub';
+
+const _ = {
+  find: _find,
+  get: _get,
+};
 
 const deepTestFolders = [
   'proj_with_no_deps',


### PR DESCRIPTION
#### What does this PR do?

Minimal change to drop our dependence on `@snyk/lodash`.